### PR TITLE
feat(pos): tambah alur antrian kitchen per item

### DIFF
--- a/apps/api/prisma/migrations/20260329052712_add_menu_prep_station/migration.sql
+++ b/apps/api/prisma/migrations/20260329052712_add_menu_prep_station/migration.sql
@@ -1,0 +1,22 @@
+-- CreateEnum
+CREATE TYPE "PrepStation" AS ENUM ('KITCHEN', 'BAR');
+
+-- CreateEnum
+CREATE TYPE "PrepStatus" AS ENUM ('PENDING', 'ACCEPTED', 'STARTED', 'READY', 'SERVED');
+
+-- AlterTable
+ALTER TABLE "Menu" ADD COLUMN     "prepStation" "PrepStation" NOT NULL DEFAULT 'KITCHEN';
+
+-- AlterTable
+ALTER TABLE "OrderDetail" ADD COLUMN     "acceptedAt" TIMESTAMP(3),
+ADD COLUMN     "prepStation" "PrepStation" NOT NULL DEFAULT 'KITCHEN',
+ADD COLUMN     "prepStatus" "PrepStatus" NOT NULL DEFAULT 'PENDING',
+ADD COLUMN     "readyAt" TIMESTAMP(3),
+ADD COLUMN     "servedAt" TIMESTAMP(3),
+ADD COLUMN     "startedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "OrderDetail_orderId_idx" ON "OrderDetail"("orderId");
+
+-- CreateIndex
+CREATE INDEX "OrderDetail_prepStation_prepStatus_idx" ON "OrderDetail"("prepStation", "prepStatus");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -46,6 +46,19 @@ enum StockReason {
   SPOIL
 }
 
+enum PrepStation {
+  KITCHEN
+  BAR
+}
+
+enum PrepStatus {
+  PENDING
+  ACCEPTED
+  STARTED
+  READY
+  SERVED
+}
+
 model User {
   id        Int      @id @default(autoincrement())
   name      String
@@ -70,15 +83,18 @@ model Category {
 }
 
 model Menu {
-  id         Int        @id @default(autoincrement())
-  name       String
-  price      Int
-  categoryId Int?
-  category   Category?  @relation(fields: [categoryId], references: [id], onDelete: SetNull)
-  recipes    Recipe[]
-  details    OrderDetail[]
-  createdAt  DateTime   @default(now())
-  updatedAt  DateTime   @updatedAt
+  id          Int          @id @default(autoincrement())
+  name        String
+  price       Int
+  categoryId  Int?
+  prepStation PrepStation  @default(KITCHEN)
+
+  category    Category?    @relation(fields: [categoryId], references: [id], onDelete: SetNull)
+  recipes     Recipe[]
+  details     OrderDetail[]
+
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
 }
 
 model Ingredient {
@@ -138,14 +154,26 @@ model Order {
 }
 
 model OrderDetail {
-  id       Int   @id @default(autoincrement())
-  orderId  Int
-  menuId   Int
-  qty      Int
-  price    Int // snapshot harga saat transaksi
-  subtotal Int
-  order    Order @relation(fields: [orderId], references: [id], onDelete: Cascade)
-  menu     Menu  @relation(fields: [menuId], references: [id])
+  id          Int         @id @default(autoincrement())
+  orderId     Int
+  menuId      Int
+  qty         Int
+  price       Int
+  subtotal    Int
+
+  prepStation PrepStation @default(KITCHEN)
+  prepStatus  PrepStatus  @default(PENDING)
+
+  acceptedAt  DateTime?
+  startedAt   DateTime?
+  readyAt     DateTime?
+  servedAt    DateTime?
+
+  order       Order       @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  menu        Menu        @relation(fields: [menuId], references: [id])
+
+  @@index([orderId])
+  @@index([prepStation, prepStatus])
 }
 
 // Ledger pergerakan stok biar bisa audit

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -97,19 +97,37 @@ async function main() {
   const menuKopiSusu = await prisma.menu.upsert({
     where: { id: 1 },
     update: {},
-    create: { id: 1, name: 'Es Kopi Susu Kanovi', price: 20000, categoryId: catMinuman.id },
+    create: {
+      id: 1,
+      name: "Es Kopi Susu Kanovi",
+      price: 20000,
+      categoryId: catMinuman.id,
+      prepStation: "KITCHEN",
+    },
   });
 
   const menuTehManis = await prisma.menu.upsert({
     where: { id: 2 },
     update: {},
-    create: { id: 2, name: 'Es Teh Manis', price: 12000, categoryId: catMinuman.id },
+    create: {
+      id: 2,
+      name: "Es Teh Manis",
+      price: 12000,
+      categoryId: catMinuman.id,
+      prepStation: "KITCHEN",
+    },
   });
 
   const menuRotiBakar = await prisma.menu.upsert({
     where: { id: 3 },
     update: {},
-    create: { id: 3, name: 'Roti Bakar Coklat', price: 18000, categoryId: catMakanan.id },
+    create: {
+      id: 3,
+      name: "Roti Bakar Coklat",
+      price: 18000,
+      categoryId: catMakanan.id,
+      prepStation: "KITCHEN",
+    },
   });
 
 

--- a/apps/api/src/controllers/menuController.ts
+++ b/apps/api/src/controllers/menuController.ts
@@ -12,10 +12,11 @@ export const createMenu = async (req: FastifyRequest, reply: FastifyReply) => {
     return reply.code(403).send({ message: "Akses ditolak. Hanya Owner." });
   }
 
-  const { name, price, categoryId } = req.body as {
+  const { name, price, categoryId, prepStation } = req.body as {
     name: string;
     price: number;
-    categoryId?: number;
+    categoryId?: number | null;
+    prepStation?: "KITCHEN" | "BAR";
   };
 
   if (!name || price === undefined || price === null) {
@@ -42,6 +43,7 @@ export const createMenu = async (req: FastifyRequest, reply: FastifyReply) => {
         name,
         price: Number(price),
         categoryId: categoryId ?? null,
+        prepStation: prepStation ?? "KITCHEN",
       },
       include: {
         category: true,
@@ -53,6 +55,7 @@ export const createMenu = async (req: FastifyRequest, reply: FastifyReply) => {
       data: newMenu,
     });
   } catch (error) {
+    console.error(error);
     return reply.code(500).send({ message: "Gagal menyimpan menu" });
   }
 };
@@ -104,10 +107,11 @@ export const updateMenu = async (req: FastifyRequest, reply: FastifyReply) => {
   }
 
   const { id } = req.params as { id: string };
-  const { name, price, categoryId } = req.body as {
+  const { name, price, categoryId, prepStation } = req.body as {
     name?: string;
     price?: number;
     categoryId?: number | null;
+    prepStation?: "KITCHEN" | "BAR";
   };
 
   if (categoryId !== undefined && categoryId !== null) {
@@ -129,6 +133,7 @@ export const updateMenu = async (req: FastifyRequest, reply: FastifyReply) => {
         ...(name !== undefined && { name }),
         ...(price !== undefined && { price: Number(price) }),
         ...(categoryId !== undefined && { categoryId }),
+        ...(prepStation !== undefined && { prepStation }),
       },
       include: {
         category: true,

--- a/apps/api/src/controllers/orderController.ts
+++ b/apps/api/src/controllers/orderController.ts
@@ -124,6 +124,11 @@ export const createOrder = async (req: FastifyRequest, reply: FastifyReply) => {
 
   const menus = await prisma.menu.findMany({
     where: { id: { in: items.map((i) => i.menuId) } },
+    select: {
+      id: true,
+      price: true,
+      prepStation: true,
+    },
   });
 
   const menuMap = new Map(menus.map((m) => [m.id, m]));
@@ -133,14 +138,16 @@ export const createOrder = async (req: FastifyRequest, reply: FastifyReply) => {
   }
 
   const details = items.map((i) => {
-    const menu = menuMap.get(i.menuId)!;
-    const subtotal = menu.price * i.qty;
+  const menu = menuMap.get(i.menuId)!;
+  const subtotal = menu.price * i.qty;
 
     return {
       menuId: menu.id,
       qty: i.qty,
       price: menu.price,
       subtotal,
+      prepStation: menu.prepStation,
+      prepStatus: "PENDING" as const,
     };
   });
 

--- a/apps/api/src/controllers/queueController.ts
+++ b/apps/api/src/controllers/queueController.ts
@@ -3,9 +3,32 @@
 import { FastifyRequest, FastifyReply } from "fastify";
 import { prisma } from "../prisma";
 
+// helper untuk derive status order
+function deriveOrderStatus(
+  details: Array<{ prepStatus: "PENDING" | "ACCEPTED" | "STARTED" | "READY" | "SERVED" }>
+): "NEW" | "IN_PROGRESS" | "READY" | "DONE" {
+  if (details.length === 0) return "NEW";
+
+  const allServed = details.every((d) => d.prepStatus === "SERVED");
+  if (allServed) return "DONE";
+
+  const allReadyOrServed = details.every(
+    (d) => d.prepStatus === "READY" || d.prepStatus === "SERVED"
+  );
+  if (allReadyOrServed) return "READY";
+
+  const hasStartedWork = details.some((d) =>
+    ["ACCEPTED", "STARTED", "READY", "SERVED"].includes(d.prepStatus)
+  );
+  if (hasStartedWork) return "IN_PROGRESS";
+
+  return "NEW";
+}
+
 // ====== 1. API LIST QUEUE PER STATION ======
 export const getActiveQueue = async (request: FastifyRequest, reply: FastifyReply) => {
-  const { station } = request.query as { station?: string };
+  const rawStation = (request.query as { station?: string }).station;
+  const station = rawStation === "BAR" ? "BAR" : "KITCHEN";
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -14,43 +37,31 @@ export const getActiveQueue = async (request: FastifyRequest, reply: FastifyRepl
     const orders = await prisma.order.findMany({
       where: {
         paymentStatus: "PAID",
-        status: { in: ["NEW", "IN_PROGRESS", "READY"] },
-        orderedAt: { gte: today }, 
+        orderedAt: { gte: today },
+        details: {
+          some: {
+            prepStation: station,
+            prepStatus: { not: "SERVED" },
+          },
+        },
       },
       include: {
+        user: true,
         details: {
-          include: {
-            menu: {
-              include: { category: true },
-            },
+          where: {
+            prepStation: station,
+            prepStatus: { not: "SERVED" },
           },
+          include: {
+            menu: { include: { category: true } },
+          },
+          orderBy: { id: "asc" },
         },
       },
       orderBy: { orderedAt: "asc" },
     });
 
-    const mappedOrders = orders.map((order) => {
-      let filteredDetails = order.details;
-
-      if (station === "BAR") {
-        filteredDetails = order.details.filter((d) => {
-          const catName = d.menu.category?.name.toLowerCase() || "";
-          return catName.includes("minum") || catName.includes("kopi") || catName.includes("teh");
-        });
-      } else if (station === "KITCHEN") {
-        filteredDetails = order.details.filter((d) => {
-          const catName = d.menu.category?.name.toLowerCase() || "";
-          return !catName.includes("minum") && !catName.includes("kopi") && !catName.includes("teh");
-        });
-      }
-
-      return {
-        ...order,
-        details: filteredDetails,
-      };
-    }).filter((order) => order.details.length > 0); 
-
-    return reply.send({ success: true, data: mappedOrders });
+    return reply.send({ success: true, data: orders });
   } catch (error) {
     console.error(error);
     return reply.code(500).send({ success: false, message: "Terjadi kesalahan sistem." });
@@ -58,26 +69,83 @@ export const getActiveQueue = async (request: FastifyRequest, reply: FastifyRepl
 };
 
 // ====== 2. API UPDATE STATUS ORDER ======
-export const updateOrderStatus = async (request: FastifyRequest, reply: FastifyReply) => {
-  const { id } = request.params as { id: string };
-  const { status } = request.body as { status: "NEW" | "IN_PROGRESS" | "READY" | "DONE" };
+export const updateOrderItemStatus = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const { detailId } = request.params as { detailId: string };
+  const { status } = request.body as {
+    status: "ACCEPTED" | "STARTED" | "READY" | "SERVED";
+  };
 
-  // Validasi keamanan: Pastikan status yang dikirim sesuai dengan Enum Prisma
-  const validStatuses = ["NEW", "IN_PROGRESS", "READY", "DONE"];
+  const validStatuses = ["ACCEPTED", "STARTED", "READY", "SERVED"];
   if (!validStatuses.includes(status)) {
-    return reply.code(400).send({ success: false, message: "Status tidak valid" });
+    return reply.code(400).send({ success: false, message: "Status item tidak valid" });
   }
 
   try {
-    const updatedOrder = await prisma.order.update({
-      where: { id: Number(id) },
-      data: { status },
+    const detail = await prisma.orderDetail.findUnique({
+      where: { id: Number(detailId) },
     });
 
-    return reply.send({ success: true, data: updatedOrder });
+    if (!detail) {
+      return reply.code(404).send({ success: false, message: "Item order tidak ditemukan" });
+    }
+
+    const now = new Date();
+
+    const timestampPatch =
+      status === "ACCEPTED"
+        ? { acceptedAt: detail.acceptedAt ?? now }
+        : status === "STARTED"
+        ? {
+            acceptedAt: detail.acceptedAt ?? now,
+            startedAt: detail.startedAt ?? now,
+          }
+        : status === "READY"
+        ? {
+            acceptedAt: detail.acceptedAt ?? now,
+            startedAt: detail.startedAt ?? now,
+            readyAt: detail.readyAt ?? now,
+          }
+        : {
+            acceptedAt: detail.acceptedAt ?? now,
+            startedAt: detail.startedAt ?? now,
+            readyAt: detail.readyAt ?? now,
+            servedAt: detail.servedAt ?? now,
+          };
+
+    const updatedDetail = await prisma.orderDetail.update({
+      where: { id: Number(detailId) },
+      data: {
+        prepStatus: status,
+        ...timestampPatch,
+      },
+      include: {
+        menu: true,
+      },
+    });
+
+    const allDetails = await prisma.orderDetail.findMany({
+      where: { orderId: detail.orderId },
+      select: { prepStatus: true },
+    });
+
+    const nextOrderStatus = deriveOrderStatus(allDetails);
+
+    await prisma.order.update({
+      where: { id: detail.orderId },
+      data: { status: nextOrderStatus },
+    });
+
+    return reply.send({
+      success: true,
+      data: updatedDetail,
+      orderStatus: nextOrderStatus,
+    });
   } catch (error) {
     console.error(error);
-    return reply.code(500).send({ success: false, message: "Gagal mengupdate status order." });
+    return reply.code(500).send({ success: false, message: "Gagal mengupdate item order." });
   }
 };
 
@@ -87,11 +155,16 @@ export const getOrderHistory = async (request: FastifyRequest, reply: FastifyRep
     const orders = await prisma.order.findMany({
       where: { paymentStatus: "PAID" },
       include: {
+        user: true,
         details: {
-          include: { menu: true },
+          include: {
+            menu: {
+              include: { category: true },
+            },
+          },
         },
       },
-      orderBy: { orderedAt: "asc" }, 
+      orderBy: { orderedAt: "desc" },
     });
 
     return reply.send({ success: true, data: orders });

--- a/apps/api/src/routes/queueRoutes.ts
+++ b/apps/api/src/routes/queueRoutes.ts
@@ -1,10 +1,13 @@
 import { FastifyInstance } from "fastify";
 import { verifyToken } from "../middleware/authMiddleware";
-import { getActiveQueue, updateOrderStatus, getOrderHistory } from "../controllers/queueController";
+import {
+  getActiveQueue,
+  updateOrderItemStatus,
+  getOrderHistory,
+} from "../controllers/queueController";
 
 export default async function queueRoutes(app: FastifyInstance) {
-  // Menggunakan prefix /api di index.ts nanti, jadi di sini tulis rutenya langsung
   app.get("/queue", { preHandler: [verifyToken] }, getActiveQueue);
-  app.patch("/queue/:id/status", { preHandler: [verifyToken] }, updateOrderStatus);
+  app.patch("/queue/items/:detailId/status", { preHandler: [verifyToken] }, updateOrderItemStatus);
   app.get("/orders/history", { preHandler: [verifyToken] }, getOrderHistory);
 }

--- a/apps/web/app/dashboard/menu/edit/[id]/page.tsx
+++ b/apps/web/app/dashboard/menu/edit/[id]/page.tsx
@@ -114,7 +114,7 @@ export default function EditMenuPage() {
 
     try {
       const res = await fetch(`${API_BASE}/api/menus/${id}`, {
-        method: "PUT",
+        method: "PATCH",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,

--- a/apps/web/app/dashboard/menu/page.tsx
+++ b/apps/web/app/dashboard/menu/page.tsx
@@ -305,7 +305,7 @@ export default function MenuListPage() {
 
     try {
       await apiRequest(`/api/menus/${editingMenu.id}`, {
-  method: "PUT",
+  method: "PATCH",
   body: JSON.stringify({
     name,
     price,

--- a/apps/web/app/features/queue/components/kitchen-order-card.tsx
+++ b/apps/web/app/features/queue/components/kitchen-order-card.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Order, PrepStatus } from "../../../../types";
+import { getWaitTimeInfo } from "../lib/get-wait-time-info";
+import KitchenOrderItemRow from "./kitchen-order-item-row";
+
+type Props = {
+  order: Order;
+  now: Date;
+  onAdvanceStatus: (detailId: number, status: Exclude<PrepStatus, "SERVED">) => void;
+};
+
+export default function KitchenOrderCard({ order, now, onAdvanceStatus }: Props) {
+  const { diffMins, isOverdue } = getWaitTimeInfo(order.orderedAt, now);
+
+  return (
+    <div className="rounded-2xl bg-kanovi-bone dark:bg-[#1a1a1a] border border-kanovi-cream/50 dark:border-white/5 shadow-sm p-4">
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <h2 className="text-lg font-bold text-kanovi-coffee dark:text-white">
+            Order #{order.id}
+          </h2>
+          <p className="text-sm text-kanovi-coffee/70 dark:text-gray-400">
+            {order.customerName || "Walk-in"}
+          </p>
+        </div>
+
+        <div
+          className={`text-xs font-bold px-3 py-1 rounded-full ${
+            isOverdue
+              ? "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300"
+              : "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+          }`}
+        >
+          {diffMins} menit
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {order.details.map((detail) => (
+          <KitchenOrderItemRow
+            key={detail.id}
+            detailId={detail.id}
+            menuName={detail.menu.name}
+            qty={detail.qty}
+            prepStatus={detail.prepStatus}
+            onAdvanceStatus={onAdvanceStatus}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/features/queue/components/kitchen-order-item-row.tsx
+++ b/apps/web/app/features/queue/components/kitchen-order-item-row.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { PrepStatus } from "../../../../types";
+import {
+  getPrepActionLabel,
+  isActivePrepStatus,
+} from "../domain/prep-status";
+
+type Props = {
+  detailId: number;
+  menuName: string;
+  qty: number;
+  prepStatus: PrepStatus;
+  onAdvanceStatus: (detailId: number, status: Exclude<PrepStatus, "SERVED">) => void;
+};
+
+export default function KitchenOrderItemRow({
+  detailId,
+  menuName,
+  qty,
+  prepStatus,
+  onAdvanceStatus,
+}: Props) {
+  const actionLabel = getPrepActionLabel(prepStatus);
+
+  return (
+    <div className="rounded-xl border border-kanovi-cream/50 dark:border-white/10 p-3 bg-white/70 dark:bg-gray-900/40">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-semibold text-kanovi-coffee dark:text-white">
+            {menuName}
+          </p>
+          <p className="text-sm text-kanovi-coffee/70 dark:text-gray-400">
+            Qty: {qty}
+          </p>
+          <p className="text-xs mt-1 text-kanovi-coffee/60 dark:text-gray-500">
+            Status: {prepStatus}
+          </p>
+        </div>
+
+        {actionLabel && isActivePrepStatus(prepStatus) && (
+          <button
+            onClick={() => onAdvanceStatus(detailId, prepStatus)}
+            className="px-3 py-2 rounded-lg bg-kanovi-coffee text-white text-sm font-medium hover:opacity-90 transition"
+          >
+            {actionLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/features/queue/components/kitchen-queue-header.tsx
+++ b/apps/web/app/features/queue/components/kitchen-queue-header.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ArrowLeft, Coffee, Moon, Sun } from "lucide-react";
+
+type Props = {
+  currentTime: Date;
+  isDarkMode: boolean;
+  onToggleTheme: () => void;
+  onBack: () => void;
+};
+
+export default function KitchenQueueHeader({
+  currentTime,
+  isDarkMode,
+  onToggleTheme,
+  onBack,
+}: Props) {
+  return (
+    <div className="flex justify-between items-center mb-6 bg-kanovi-bone dark:bg-[#1a1a1a] p-4 rounded-2xl shadow-sm border border-kanovi-cream/50 dark:border-white/5">
+      <div className="flex items-center gap-4">
+        <button
+          onClick={onBack}
+          className="p-3 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-xl transition text-kanovi-coffee dark:text-gray-200 border border-kanovi-cream/50 dark:border-transparent"
+        >
+          <ArrowLeft className="w-6 h-6" />
+        </button>
+
+        <h1 className="text-xl md:text-3xl font-bold flex items-center gap-3 text-kanovi-coffee dark:text-white">
+          <Coffee className="w-7 h-7 md:w-8 md:h-8 text-yellow-600 dark:text-yellow-500" />
+          <span className="hidden sm:inline">KANOVI KITCHEN DISPLAY</span>
+          <span className="sm:hidden">KITCHEN</span>
+        </h1>
+      </div>
+
+      <div className="flex items-center gap-3 md:gap-4">
+        <div className="bg-white dark:bg-gray-800 px-4 py-2.5 rounded-xl shadow-sm border border-kanovi-cream/50 dark:border-transparent font-mono text-base md:text-lg text-kanovi-coffee dark:text-gray-200 font-bold">
+          {currentTime.toLocaleTimeString("id-ID", {
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </div>
+
+        <button
+          onClick={onToggleTheme}
+          className="p-3 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-xl transition text-kanovi-coffee dark:text-yellow-400 border border-kanovi-cream/50 dark:border-transparent"
+        >
+          {isDarkMode ? <Sun className="w-6 h-6" /> : <Moon className="w-6 h-6" />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/features/queue/domain/prep-status.ts
+++ b/apps/web/app/features/queue/domain/prep-status.ts
@@ -1,0 +1,30 @@
+import { PrepStatus } from "../../../../types";
+
+export type ActivePrepStatus = Exclude<PrepStatus, "SERVED">;
+export type NextPrepStatus = "ACCEPTED" | "STARTED" | "READY" | "SERVED";
+
+export const nextPrepStatusMap: Record<ActivePrepStatus, NextPrepStatus> = {
+  PENDING: "ACCEPTED",
+  ACCEPTED: "STARTED",
+  STARTED: "READY",
+  READY: "SERVED",
+};
+
+export function getPrepActionLabel(status: PrepStatus): string | null {
+  switch (status) {
+    case "PENDING":
+      return "Terima";
+    case "ACCEPTED":
+      return "Mulai";
+    case "STARTED":
+      return "Siap";
+    case "READY":
+      return "Sajikan";
+    default:
+      return null;
+  }
+}
+
+export function isActivePrepStatus(status: PrepStatus): status is ActivePrepStatus {
+  return status !== "SERVED";
+}

--- a/apps/web/app/features/queue/hooks/use-kitchen-queue.ts
+++ b/apps/web/app/features/queue/hooks/use-kitchen-queue.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Order, PrepStatus } from "../../../../types";
+import { api } from "../../../../lib/api";
+import {
+  isActivePrepStatus,
+  nextPrepStatusMap,
+  ActivePrepStatus,
+} from "../domain/prep-status";
+
+export function useKitchenQueue() {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchQueue = useCallback(async () => {
+    try {
+      const json = await api.getQueue("KITCHEN");
+      setOrders(json.data || []);
+    } catch (error) {
+      console.error("Gagal mengambil data antrian", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchQueue();
+
+    const pollingInterval = setInterval(fetchQueue, 10000);
+
+    return () => {
+      clearInterval(pollingInterval);
+    };
+  }, [fetchQueue]);
+
+  const updateItemStatus = useCallback(
+    async (detailId: number, currentStatus: ActivePrepStatus) => {
+      const nextStatus = nextPrepStatusMap[currentStatus];
+      if (!nextStatus) return;
+
+      try {
+        await api.updateOrderItemStatus(detailId, nextStatus);
+        await fetchQueue();
+      } catch (error) {
+        console.error("Gagal update status item", error);
+        alert("Gagal mengupdate status item pesanan.");
+      }
+    },
+    [fetchQueue]
+  );
+
+  const activeOrders = useMemo(() => {
+    return orders
+      .map((order) => ({
+        ...order,
+        details: order.details.filter((detail) => detail.prepStatus !== "SERVED"),
+      }))
+      .filter((order) => order.details.length > 0);
+  }, [orders]);
+
+  return {
+    orders: activeOrders,
+    isLoading,
+    refreshQueue: fetchQueue,
+    updateItemStatus,
+  };
+}

--- a/apps/web/app/features/queue/lib/get-wait-time-info.ts
+++ b/apps/web/app/features/queue/lib/get-wait-time-info.ts
@@ -1,0 +1,9 @@
+export function getWaitTimeInfo(orderedAt: string, now: Date) {
+  const orderTime = new Date(orderedAt).getTime();
+  const diffMins = Math.floor((now.getTime() - orderTime) / 60000);
+
+  return {
+    diffMins,
+    isOverdue: diffMins >= 15,
+  };
+}

--- a/apps/web/app/queue/page.tsx
+++ b/apps/web/app/queue/page.tsx
@@ -1,29 +1,17 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Coffee, ArrowLeft, Sun, Moon, CheckCircle } from "lucide-react"; // Clock & PlayCircle sudah dihapus karena pindah ke dalam komponen
+import { useEffect, useState } from "react";
+import { CheckCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { Order } from "../../types";
-import { api } from "../../lib/api";
-import QueueCard from "../components/QueueCard";
+import KitchenQueueHeader from "../features/queue/components/kitchen-queue-header";
+import KitchenOrderCard from "../features/queue/components/kitchen-order-card";
+import { useKitchenQueue } from "../features/queue/hooks/use-kitchen-queue";
 
-export default function UnifiedQueueScreen() {
+export default function KitchenQueuePage() {
   const router = useRouter();
-  const [orders, setOrders] = useState<Order[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { orders, isLoading, updateItemStatus } = useKitchenQueue();
   const [currentTime, setCurrentTime] = useState(new Date());
   const [isDarkMode, setIsDarkMode] = useState(false);
-
-  const fetchQueue = async () => {
-    try {
-      const json = await api.getQueue();
-      setOrders(json.data || []);
-    } catch (error) {
-      console.error("Gagal mengambil data antrian", error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   useEffect(() => {
     const savedTheme = localStorage.getItem("kanovi_theme");
@@ -32,14 +20,9 @@ export default function UnifiedQueueScreen() {
       document.documentElement.classList.add("dark");
     }
 
-    fetchQueue(); 
-    const pollingInterval = setInterval(fetchQueue, 10000); 
-    const timeInterval = setInterval(() => setCurrentTime(new Date()), 60000); 
+    const timeInterval = setInterval(() => setCurrentTime(new Date()), 60000);
 
-    return () => {
-      clearInterval(pollingInterval);
-      clearInterval(timeInterval);
-    };
+    return () => clearInterval(timeInterval);
   }, []);
 
   const toggleTheme = () => {
@@ -49,75 +32,39 @@ export default function UnifiedQueueScreen() {
     localStorage.setItem("kanovi_theme", isDark ? "dark" : "light");
   };
 
-  const updateStatus = async (orderId: number, newStatus: string) => {
-    try {
-      setOrders((prev) => prev.map((o) => (o.id === orderId ? { ...o, status: newStatus as any } : o)));
-      
-      // 1 BARIS SAKTI UPDATE API
-      await api.updateOrderStatus(orderId, newStatus);
-      fetchQueue();
-    } catch (error) {
-      console.error("Gagal update status", error);
-      alert("Gagal mengupdate status pesanan.");
-    }
-  };
-
-  const getWaitTimeInfo = (orderedAt: string) => {
-    const orderTime = new Date(orderedAt).getTime();
-    const diffMins = Math.floor((currentTime.getTime() - orderTime) / 60000);
-    return { diffMins, isOverdue: diffMins >= 15 };
-  };
-
   return (
     <div className="min-h-screen bg-kanovi-paper dark:bg-kanovi-darker p-4 md:p-6 font-sans transition-colors duration-300">
-      
-      {/* --- HEADER --- */}
-      <div className="flex justify-between items-center mb-6 bg-kanovi-bone dark:bg-[#1a1a1a] p-4 rounded-2xl shadow-sm border border-kanovi-cream/50 dark:border-white/5">
-        <div className="flex items-center gap-4">
-          <button onClick={() => router.push('/pos')} className="p-3 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-xl transition text-kanovi-coffee dark:text-gray-200 border border-kanovi-cream/50 dark:border-transparent">
-            <ArrowLeft className="w-6 h-6" />
-          </button>
-          <h1 className="text-xl md:text-3xl font-bold flex items-center gap-3 text-kanovi-coffee dark:text-white">
-            <Coffee className="w-7 h-7 md:w-8 md:h-8 text-yellow-600 dark:text-yellow-500" />
-            <span className="hidden sm:inline">KANOVI STATION (BAR & KITCHEN)</span>
-            <span className="sm:hidden">STATION</span>
-          </h1>
-        </div>
-        <div className="flex items-center gap-3 md:gap-4">
-          <div className="bg-white dark:bg-gray-800 px-4 py-2.5 rounded-xl shadow-sm border border-kanovi-cream/50 dark:border-transparent font-mono text-base md:text-lg text-kanovi-coffee dark:text-gray-200 font-bold">
-            {currentTime.toLocaleTimeString('id-ID', { hour: '2-digit', minute: '2-digit' })}
-          </div>
-          <button onClick={toggleTheme} className="p-3 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-xl transition text-kanovi-coffee dark:text-yellow-400 border border-kanovi-cream/50 dark:border-transparent">
-            {isDarkMode ? <Sun className="w-6 h-6" /> : <Moon className="w-6 h-6" />}
-          </button>
-        </div>
-      </div>
+      <KitchenQueueHeader
+        currentTime={currentTime}
+        isDarkMode={isDarkMode}
+        onToggleTheme={toggleTheme}
+        onBack={() => router.push("/pos")}
+      />
 
-      {/* --- MAIN CONTENT --- */}
       {isLoading ? (
-        <p className="text-gray-500 dark:text-gray-400 text-center mt-10">Memuat antrian...</p>
-      ) : orders.filter(o => o.status !== 'DONE').length === 0 ? (
+        <p className="text-gray-500 dark:text-gray-400 text-center mt-10">
+          Memuat antrian...
+        </p>
+      ) : orders.length === 0 ? (
         <div className="text-center py-20 bg-kanovi-bone dark:bg-[#1a1a1a] rounded-3xl shadow-sm border border-kanovi-cream/50 dark:border-white/5 mt-10">
           <CheckCircle className="w-20 h-20 text-green-500 mx-auto mb-6 opacity-80" />
-          <h2 className="text-2xl font-bold text-kanovi-coffee dark:text-white">Station Bersih!</h2>
-          <p className="text-kanovi-coffee/70 dark:text-gray-400 mt-2">Belum ada pesanan yang perlu dikerjakan.</p>
+          <h2 className="text-2xl font-bold text-kanovi-coffee dark:text-white">
+            Kitchen Bersih!
+          </h2>
+          <p className="text-kanovi-coffee/70 dark:text-gray-400 mt-2">
+            Belum ada item pesanan yang perlu dikerjakan.
+          </p>
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6">
-
-          {orders.filter(o => o.status !== 'DONE').map((order) => {
-            const { diffMins, isOverdue } = getWaitTimeInfo(order.orderedAt);
-            return (
-              <QueueCard 
-                key={order.id} 
-                order={order} 
-                diffMins={diffMins} 
-                isOverdue={isOverdue} 
-                onUpdateStatus={updateStatus} 
-              />
-            );
-          })}
-
+          {orders.map((order) => (
+            <KitchenOrderCard
+              key={order.id}
+              order={order}
+              now={currentTime}
+              onAdvanceStatus={updateItemStatus}
+            />
+          ))}
         </div>
       )}
     </div>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -36,21 +36,22 @@ export const fetchApi = async (endpoint: string, options: RequestInit = {}) => {
 export const api = {
   getMenus: () => fetchApi("/api/menus"),
 
-  getQueue: (station?: string) =>
-    fetchApi(station ? `/api/queue?station=${station}` : "/api/queue"),
+  getQueue: (station: "KITCHEN" | "BAR" = "KITCHEN") =>
+    fetchApi(`/api/queue?station=${station}`),
 
-  updateOrderStatus: (id: number, status: string) =>
-    fetchApi(`/api/queue/${id}/status`, {
+  updateOrderItemStatus: (
+    detailId: number,
+    status: "ACCEPTED" | "STARTED" | "READY" | "SERVED"
+  ) =>
+    fetchApi(`/api/queue/items/${detailId}/status`, {
       method: "PATCH",
       body: JSON.stringify({ status }),
     }),
 
   getHistory: () => fetchApi("/api/orders/history"),
 
-  // API untuk manajemen bahan baku
   getIngredients: () => fetchApi("/api/ingredients"),
 
-  // API untuk recipe menu
   getMenuRecipe: (menuId: number) =>
     fetchApi(`/api/menus/${menuId}/recipe`),
 
@@ -75,14 +76,12 @@ export const api = {
       body: JSON.stringify(data),
     }),
 
-  // Fungsi untuk menyesuaikan stok bahan baku
   adjustStock: (id: number, qtyChange: number, reason: string) =>
     fetchApi(`/api/ingredients/${id}/adjust`, {
       method: "POST",
       body: JSON.stringify({ qtyChange, reason }),
     }),
 
-  // API untuk manajemen pesanan
   createOrder: (data: { origin: string; customerName?: string; items: any[] }) =>
     fetchApi("/api/orders", {
       method: "POST",

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,5 +1,14 @@
 export type PaymentMethod = "CASH" | "QRIS";
 
+export type PrepStation = "KITCHEN" | "BAR";
+
+export type PrepStatus =
+  | "PENDING"
+  | "ACCEPTED"
+  | "STARTED"
+  | "READY"
+  | "SERVED";
+
 export type Category = {
   id: number;
   name: string;
@@ -12,6 +21,7 @@ export type Menu = {
   price: number;
   categoryId?: number | null;
   category?: Category | null;
+  prepStation: PrepStation;
 };
 
 export type CartItem = Menu & {
@@ -20,16 +30,24 @@ export type CartItem = Menu & {
 
 export type OrderDetail = {
   id: number;
+  orderId: number;
+  menuId: number;
   qty: number;
   price: number;
   subtotal: number;
+  prepStation: PrepStation;
+  prepStatus: PrepStatus;
+  acceptedAt?: string | null;
+  startedAt?: string | null;
+  readyAt?: string | null;
+  servedAt?: string | null;
   menu: Menu;
 };
 
 export type Order = {
   id: number;
   customerName: string | null;
-  status: "NEW" | "IN_PROGRESS" | "READY" | "DONE";
+  status: "NEW" | "IN_PROGRESS" | "READY" | "DONE" | "CANCELED";
   paymentStatus: "UNPAID" | "PAID" | "VOID";
   paymentMethod?: PaymentMethod | null;
   totalPrice: number;
@@ -79,6 +97,7 @@ export type MenuRecipeResponse = {
     id: number;
     name: string;
     price: number;
+    prepStation: PrepStation;
   };
   items: RecipeItem[];
 };


### PR DESCRIPTION
## Perubahan
- menambahkan `prepStation` pada menu
- menambahkan `prepStatus` pada `OrderDetail`
- menambahkan timestamp item-level: `acceptedAt`, `startedAt`, `readyAt`, `servedAt`
- mengubah alur queue dari level order menjadi level item
- memperbarui tipe data frontend/backend
- memperbarui integrasi API
- mengubah halaman queue menjadi kitchen display
- seluruh item saat ini diarahkan ke `KITCHEN`
- memperbaiki method update menu dari PUT ke PATCH

## Alasan
Perubahan ini diperlukan agar proses produksi pesanan dapat berjalan tanpa kertas. Kasir tetap membuat satu order, sedangkan kitchen hanya melihat item yang relevan dan setiap item memiliki status kerja masing-masing.

## Catatan Operasional
Untuk kondisi Kanovi saat ini, seluruh makanan dan minuman diarahkan ke `KITCHEN` karena bar masih menyatu dengan POS dan belum menggunakan display terpisah.

## Menjalankan
```bash
pnpm install
pnpm db:migrate --name add-item-prep-workflow
pnpm --filter api prisma generate
pnpm seed
pnpm dev