### PR TITLE
feat: add menu availability status

### DIFF
--- a/apps/api/prisma/migrations/20260427064757_init/migration.sql
+++ b/apps/api/prisma/migrations/20260427064757_init/migration.sql
@@ -1,0 +1,58 @@
+-- CreateEnum
+CREATE TYPE "Branch" AS ENUM ('PUSAT', 'RESTART');
+
+-- CreateEnum
+CREATE TYPE "SessionStatus" AS ENUM ('OPEN', 'CLOSED');
+
+-- AlterTable
+ALTER TABLE "Order" ADD COLUMN     "branch" "Branch" NOT NULL DEFAULT 'PUSAT',
+ADD COLUMN     "sessionId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "CashSession" (
+    "id" SERIAL NOT NULL,
+    "branch" "Branch" NOT NULL,
+    "openedBy" TEXT NOT NULL,
+    "openedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "initialCash" INTEGER NOT NULL,
+    "status" "SessionStatus" NOT NULL DEFAULT 'OPEN',
+    "closedBy" TEXT,
+    "closedAt" TIMESTAMP(3),
+    "expectedCash" INTEGER,
+    "actualCash" INTEGER,
+    "difference" INTEGER,
+    "note" TEXT,
+
+    CONSTRAINT "CashSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Expense" (
+    "id" SERIAL NOT NULL,
+    "sessionId" INTEGER NOT NULL,
+    "branch" "Branch" NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "description" TEXT NOT NULL,
+    "recordedBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Expense_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CashSession_status_idx" ON "CashSession"("status");
+
+-- CreateIndex
+CREATE INDEX "CashSession_branch_idx" ON "CashSession"("branch");
+
+-- CreateIndex
+CREATE INDEX "Expense_sessionId_idx" ON "Expense"("sessionId");
+
+-- CreateIndex
+CREATE INDEX "Order_sessionId_idx" ON "Order"("sessionId");
+
+-- AddForeignKey
+ALTER TABLE "Order" ADD CONSTRAINT "Order_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "CashSession"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "CashSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260427094015_add_menu_is_available/migration.sql
+++ b/apps/api/prisma/migrations/20260427094015_add_menu_is_available/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Menu" ADD COLUMN     "isAvailable" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateIndex
+CREATE INDEX "Menu_isAvailable_idx" ON "Menu"("isAvailable");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -105,7 +105,8 @@ model Menu {
   name        String      // Nama makanan/minuman
   price       Int         // Harga jual
   categoryId  Int?        // ID kategori (bisa kosong)
-  prepStation PrepStation @default(KITCHEN) // Dibuat di Bar atau Kitchen?
+  prepStation PrepStation @default(KITCHEN) 
+  isAvailable Boolean  @default(true)
 
   category    Category?     @relation(fields: [categoryId], references: [id], onDelete: SetNull)
   recipes     Recipe[]      // Relasi: Resep bahan baku yang dibutuhkan
@@ -113,6 +114,7 @@ model Menu {
 
   createdAt   DateTime    @default(now())
   updatedAt   DateTime    @updatedAt
+  @@index([isAvailable])
 }
 
 model Ingredient {

--- a/apps/api/src/controllers/menuController.ts
+++ b/apps/api/src/controllers/menuController.ts
@@ -12,11 +12,12 @@ export const createMenu = async (req: FastifyRequest, reply: FastifyReply) => {
     return reply.code(403).send({ message: "Akses ditolak. Hanya Owner." });
   }
 
-  const { name, price, categoryId, prepStation } = req.body as {
+  const { name, price, categoryId, prepStation, isAvailable } = req.body as {
     name: string;
     price: number;
     categoryId?: number | null;
     prepStation?: "KITCHEN" | "BAR";
+    isAvailable?: boolean;
   };
 
   if (!name || price === undefined || price === null) {
@@ -44,6 +45,8 @@ export const createMenu = async (req: FastifyRequest, reply: FastifyReply) => {
         price: Number(price),
         categoryId: categoryId ?? null,
         prepStation: prepStation ?? "KITCHEN",
+        isAvailable: isAvailable ?? true,
+
       },
       include: {
         category: true,
@@ -107,11 +110,12 @@ export const updateMenu = async (req: FastifyRequest, reply: FastifyReply) => {
   }
 
   const { id } = req.params as { id: string };
-  const { name, price, categoryId, prepStation } = req.body as {
+  const { name, price, categoryId, prepStation, isAvailable } = req.body as {
     name?: string;
     price?: number;
     categoryId?: number | null;
     prepStation?: "KITCHEN" | "BAR";
+    isAvailable?: boolean;
   };
 
   if (categoryId !== undefined && categoryId !== null) {
@@ -126,6 +130,12 @@ export const updateMenu = async (req: FastifyRequest, reply: FastifyReply) => {
     }
   }
 
+    if (isAvailable !== undefined && typeof isAvailable !== "boolean") {
+    return reply.code(400).send({
+      message: "Status ketersediaan menu harus boolean.",
+    });
+  }
+
   try {
     const updatedMenu = await prisma.menu.update({
       where: { id: Number(id) },
@@ -134,6 +144,7 @@ export const updateMenu = async (req: FastifyRequest, reply: FastifyReply) => {
         ...(price !== undefined && { price: Number(price) }),
         ...(categoryId !== undefined && { categoryId }),
         ...(prepStation !== undefined && { prepStation }),
+        ...(isAvailable !== undefined && { isAvailable }),
       },
       include: {
         category: true,

--- a/apps/api/src/controllers/orderController.ts
+++ b/apps/api/src/controllers/orderController.ts
@@ -133,8 +133,10 @@ export const createOrder = async (req: FastifyRequest, reply: FastifyReply) => {
     where: { id: { in: items.map((i) => i.menuId) } },
     select: {
       id: true,
+      name: true,
       price: true,
       prepStation: true,
+      isAvailable: true,
     },
   });
 
@@ -142,6 +144,19 @@ export const createOrder = async (req: FastifyRequest, reply: FastifyReply) => {
 
   if (menus.length !== new Set(items.map((i) => i.menuId)).size) {
     return reply.code(400).send({ error: "Ada menu yang tidak ditemukan." });
+  }
+
+  const unavailableMenus = menus.filter((menu) => !menu.isAvailable);
+
+  if (unavailableMenus.length > 0) {
+    return reply.code(409).send({
+      error: "MENU_NOT_AVAILABLE",
+      message: "Ada menu yang sedang tidak tersedia.",
+      menus: unavailableMenus.map((menu) => ({
+        id: menu.id,
+        name: menu.name,
+      })),
+    });
   }
 
   const details = items.map((i) => {
@@ -220,10 +235,22 @@ export const payOrder = async (req: FastifyRequest, reply: FastifyReply) => {
       `SELECT id FROM "Order" WHERE id = ${id} FOR UPDATE`
     );
 
-    const lockedOrder = await tx.order.findUnique({
-      where: { id },
-      include: { details: true },
-    });
+  const lockedOrder = await tx.order.findUnique({
+    where: { id },
+    include: {
+      details: {
+        include: {
+          menu: {
+            select: {
+              id: true,
+              name: true,
+              isAvailable: true,
+            },
+          },
+        },
+      },
+    },
+  });
 
     if (!lockedOrder) {
       return { kind: "NOT_FOUND" as const };
@@ -239,6 +266,20 @@ export const payOrder = async (req: FastifyRequest, reply: FastifyReply) => {
     if (lockedOrder.paymentStatus === "VOID") {
       return { kind: "VOID" as const };
     }
+
+    const unavailableMenus = lockedOrder.details
+  .map((detail) => detail.menu)
+  .filter((menu) => !menu.isAvailable);
+
+  if (unavailableMenus.length > 0) {
+    return {
+      kind: "MENU_NOT_AVAILABLE" as const,
+      menus: unavailableMenus.map((menu) => ({
+        id: menu.id,
+        name: menu.name,
+      })),
+    };
+  }
 
     const menuIds = [...new Set(lockedOrder.details.map((d) => d.menuId))];
 
@@ -321,6 +362,14 @@ export const payOrder = async (req: FastifyRequest, reply: FastifyReply) => {
   if (txResult.kind === "VOID") {
     return reply.code(409).send({ error: "Order already VOID" });
   }
+
+  if (txResult.kind === "MENU_NOT_AVAILABLE") {
+  return reply.code(409).send({
+    error: "MENU_NOT_AVAILABLE",
+    message: "Ada menu yang sedang tidak tersedia.",
+    menus: txResult.menus,
+  });
+}
 
   if (txResult.kind === "SHORTAGE") {
     return reply.code(409).send({

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -46,3 +46,39 @@ app.post("/dev/seed", async (_req, reply) => {
 });
 
 app.listen({ port, host: "0.0.0.0" });
+
+async function validateMenusAvailable(items: Array<{ menuId: number; qty: number }>) {
+  const menuIds = [...new Set(items.map((item) => item.menuId))];
+
+  const menus = await prisma.menu.findMany({
+    where: { id: { in: menuIds } },
+    select: { id: true, name: true, isAvailable: true },
+  });
+
+  if (menus.length !== menuIds.length) {
+    return {
+      ok: false as const,
+      code: 400,
+      payload: {
+        error: "MENU_NOT_FOUND",
+        message: "Ada menu yang tidak ditemukan.",
+      },
+    };
+  }
+
+  const unavailableMenus = menus.filter((menu) => !menu.isAvailable);
+
+  if (unavailableMenus.length > 0) {
+    return {
+      ok: false as const,
+      code: 409,
+      payload: {
+        error: "MENU_NOT_AVAILABLE",
+        message: "Ada menu yang sedang tidak tersedia.",
+        menus: unavailableMenus,
+      },
+    };
+  }
+
+  return { ok: true as const };
+}

--- a/apps/web/app/dashboard/menu/create/page.tsx
+++ b/apps/web/app/dashboard/menu/create/page.tsx
@@ -18,6 +18,7 @@ export default function CreateMenuPage() {
   const [categoryId, setCategoryId] = useState("");
   const [name, setName] = useState("");
   const [price, setPrice] = useState("");
+  const [isAvailable, setIsAvailable] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
@@ -97,6 +98,7 @@ export default function CreateMenuPage() {
           name: trimmedName,
           price: numericPrice,
           categoryId: categoryId ? Number(categoryId) : null,
+          isAvailable,
         }),
       });
 
@@ -179,6 +181,25 @@ export default function CreateMenuPage() {
               ))}
             </select>
           </div>
+
+          <div>
+            <label className="block text-sm font-semibold mb-2 text-kanovi-coffee dark:text-kanovi-bone">
+              Status Ketersediaan
+            </label>
+
+            <select
+              value={isAvailable ? "available" : "unavailable"}
+              onChange={(e) => setIsAvailable(e.target.value === "available")}
+              className="w-full px-4 py-3 bg-kanovi-paper dark:bg-black/20 border border-kanovi-cream dark:border-white/10 rounded-xl text-kanovi-coffee dark:text-kanovi-bone"
+            >
+              <option value="available">Tersedia</option>
+              <option value="unavailable">Tidak Tersedia</option>
+            </select>
+
+            <p className="mt-2 text-xs text-kanovi-coffee/60 dark:text-kanovi-cream/50">
+              Default menu baru adalah tersedia. Ubah ke tidak tersedia jika menu belum siap dijual.
+            </p>
+        </div>
 
           <button
             type="submit"

--- a/apps/web/app/dashboard/menu/page.tsx
+++ b/apps/web/app/dashboard/menu/page.tsx
@@ -16,6 +16,7 @@ type Menu = {
   id: number;
   name: string;
   price: number;
+  isAvailable: boolean;
   categoryId?: number | null;
   category?: Category | null;
 };
@@ -54,7 +55,9 @@ export default function MenuListPage() {
   const [editingMenu, setEditingMenu] = useState<Menu | null>(null);
   const [editName, setEditName] = useState("");
   const [editPrice, setEditPrice] = useState("");
+  const [editIsAvailable, setEditIsAvailable] = useState(true);
   const [isEditSaving, setIsEditSaving] = useState(false);
+  const [availabilityUpdatingId, setAvailabilityUpdatingId] = useState<number | null>(null);
   const getToken = () => document.cookie.split("; ").find((row) => row.startsWith("kanovi_token="))?.split("=")[1];
 
     const apiRequest = async (path: string, options: RequestInit = {}) => {
@@ -272,15 +275,18 @@ export default function MenuListPage() {
     setEditName(menu.name);
     setEditPrice(String(menu.price));
     setEditCategoryId(menu.categoryId ? String(menu.categoryId) : "");
+    setEditIsAvailable(menu.isAvailable);
     setIsEditModalOpen(true);
   };
 
-    const closeEditModal = () => {
+  const closeEditModal = () => {
   setIsEditModalOpen(false);
   setEditingMenu(null);
   setEditName("");
   setEditPrice("");
   setEditCategoryId("");
+  setEditIsAvailable(true);
+
 };
 
 
@@ -310,9 +316,9 @@ export default function MenuListPage() {
     name,
     price,
     categoryId: editCategoryId ? Number(editCategoryId) : null,
+    isAvailable: editIsAvailable,
   }),
 });
-
       toast.success("Menu berhasil diupdate", { id: toastId });
       closeEditModal();
       fetchMenus();
@@ -344,6 +350,47 @@ const filteredMenus = menus.filter((menu) => {
 
   return matchSearch && matchCategory;
 });
+
+const toggleMenuAvailability = async (menu: Menu) => {
+  const nextStatus = !menu.isAvailable;
+
+  setAvailabilityUpdatingId(menu.id);
+
+  const toastId = toast.loading(
+    nextStatus
+      ? "Mengubah menu menjadi tersedia..."
+      : "Mengubah menu menjadi tidak tersedia..."
+  );
+
+  try {
+    await apiRequest(`/api/menus/${menu.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({
+        isAvailable: nextStatus,
+      }),
+    });
+
+    toast.success(
+      nextStatus
+        ? `${menu.name} sekarang tersedia.`
+        : `${menu.name} sekarang tidak tersedia.`,
+      { id: toastId }
+    );
+
+    await fetchMenus();
+  } catch (error) {
+    console.error("toggleMenuAvailability error:", error);
+
+    toast.error(
+      error instanceof Error
+        ? error.message
+        : "Gagal mengubah status ketersediaan menu.",
+      { id: toastId }
+    );
+  } finally {
+    setAvailabilityUpdatingId(null);
+  }
+};
 
   return (
     <div className="max-w-5xl mx-auto w-full relative">
@@ -402,19 +449,47 @@ const filteredMenus = menus.filter((menu) => {
                 <th className="p-3 md:p-4 font-bold">Nama Menu</th>
                 <th className="p-3 md:p-4 font-bold">Harga</th>
                 <th className="p-3 md:p-4 font-bold">Kategori</th>
-                <th className="p-3 md:p-4 font-bold text-center">Aksi</th>
+                <th className="p-3 md:p-4 font-bold">Status</th>
+                <th className="p-3 md:p-4 font-bold text-center">Aksi</th>  
               </tr>
             </thead>
             <tbody className="divide-y divide-kanovi-cream/40 dark:divide-white/5 text-sm md:text-base">
-              {filteredMenus.map((menu: any) => (
+              {filteredMenus.map((menu) => (
                 // HOVER TABEL AMAN DARI FLASHBANG
                 <tr key={menu.id} className="hover:bg-kanovi-cream/20 dark:hover:bg-white/5 transition-colors">
                   <td className="p-3 md:p-4 text-kanovi-coffee/60 dark:text-kanovi-cream/50">#{menu.id}</td>
                   <td className="p-3 md:p-4 font-semibold text-kanovi-coffee dark:text-kanovi-bone">{menu.name}</td>
                   <td className="p-3 md:p-4 text-kanovi-wood dark:text-kanovi-cream">Rp {menu.price.toLocaleString("id-ID")}</td>
                   <td className="p-3 md:p-4 text-kanovi-coffee dark:text-kanovi-bone">{menu.category?.name ?? "-"}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={
+                        menu.isAvailable
+                          ? "inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300"
+                          : "inline-flex items-center rounded-full bg-red-100 px-3 py-1 text-xs font-semibold text-red-700 dark:bg-red-500/20 dark:text-red-300"
+                      }
+                    >
+                      {menu.isAvailable ? "Tersedia" : "Tidak Tersedia"}
+                    </span>
+                  </td>
                   <td className="p-3 md:p-4 text-center">
                     <div className="flex justify-center items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => toggleMenuAvailability(menu)}
+                        disabled={availabilityUpdatingId === menu.id}
+                        className={
+                          menu.isAvailable
+                            ? "px-3 py-1.5 bg-red-100 hover:bg-red-200 text-red-700 dark:bg-red-500/20 dark:hover:bg-red-500/30 dark:text-red-300 text-xs md:text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            : "px-3 py-1.5 bg-emerald-100 hover:bg-emerald-200 text-emerald-700 dark:bg-emerald-500/20 dark:hover:bg-emerald-500/30 dark:text-emerald-300 text-xs md:text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        }
+                      >
+                        {availabilityUpdatingId === menu.id
+                          ? "Menyimpan..."
+                          : menu.isAvailable
+                            ? "Jadikan Tidak Tersedia"
+                            : "Jadikan Tersedia"}
+                      </button>
                       <button
                         onClick={() => openEditModal(menu)}
                         className="px-3 py-1.5 bg-kanovi-cream/40 hover:bg-kanovi-cream/70 dark:bg-white/5 dark:hover:bg-white/10 text-kanovi-coffee dark:text-kanovi-cream text-xs md:text-sm font-medium rounded-md transition-colors"
@@ -527,6 +602,26 @@ const filteredMenus = menus.filter((menu) => {
                 placeholder="0"
                 className="w-full px-4 py-3 bg-kanovi-paper dark:bg-black/20 border border-kanovi-cream dark:border-white/10 rounded-xl text-kanovi-coffee dark:text-kanovi-bone"
               />
+
+            <div>
+                <label className="block text-sm font-semibold mb-2 text-kanovi-coffee dark:text-kanovi-bone">
+                  Status Ketersediaan
+                </label>
+
+                <select
+                  value={editIsAvailable ? "available" : "unavailable"}
+                  onChange={(e) => setEditIsAvailable(e.target.value === "available")}
+                  className="w-full px-4 py-3 bg-kanovi-paper dark:bg-black/20 border border-kanovi-cream dark:border-white/10 rounded-xl text-kanovi-coffee dark:text-kanovi-bone"
+                >
+                  <option value="available">Tersedia</option>
+                  <option value="unavailable">Tidak Tersedia</option>
+                </select>
+
+                <p className="mt-2 text-xs text-kanovi-coffee/60 dark:text-kanovi-cream/50">
+                  Menu yang tidak tersedia tetap muncul di dashboard, tetapi tidak bisa dipilih di POS.
+                </p>
+            </div>
+
             </div>
           </div>
 

--- a/apps/web/app/pos/page.tsx
+++ b/apps/web/app/pos/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import { ShoppingCart, Trash2, Menu as MenuIcon, X, MonitorPlay, History, LogOut, Receipt, Calculator, BookmarkPlus, Library } from "lucide-react";
 import { PaymentMethod, Menu, CartItem, ShortageItem } from "../../types";
 import { api } from "../../lib/api";
-// IMPORT HoldBillModal yang baru kita buat
 import { ClearCartModal, CashModal, QrisModal, ShortageModal, SuccessModal, HoldBillModal } from "../components/PosModals";
 import OpeningSessionModal from "../components/OpeningSessionModal";
 import { ExpenseModal, ClosingModal } from "../components/FinanceModals";
@@ -93,15 +92,49 @@ export default function POSPage() {
   };
 
   const addToCart = (menu: Menu) => {
+    if (!menu.isAvailable) {
+      alert(`${menu.name} sedang tidak tersedia.`);
+      return;
+    }
+
     setCart((prev) => {
       const exists = prev.find((i) => i.id === menu.id);
-      if (exists) return prev.map((i) => i.id === menu.id ? { ...i, qty: i.qty + 1 } : i);
+
+      if (exists) {
+        return prev.map((i) =>
+          i.id === menu.id ? { ...i, qty: i.qty + 1 } : i
+        );
+      }
+
       return [...prev, { ...menu, qty: 1 }];
     });
   };
 
+  const getUnavailableCartItems = () => {
+  const latestMenuMap = new Map(menus.map((menu) => [menu.id, menu]));
+
+    return cart.filter((cartItem) => {
+      const latestMenu = latestMenuMap.get(cartItem.id);
+
+      return latestMenu?.isAvailable === false;
+    });
+  };
+
   const updateQty = (id: number, delta: number) => {
-    setCart((prev) => prev.map((i) => i.id === id ? { ...i, qty: i.qty + delta } : i).filter((i) => i.qty > 0));
+    if (delta > 0) {
+      const latestMenu = menus.find((menu) => menu.id === id);
+
+      if (latestMenu?.isAvailable === false) {
+        alert(`${latestMenu.name} sedang tidak tersedia.`);
+        return;
+      }
+    }
+
+    setCart((prev) =>
+      prev
+        .map((i) => (i.id === id ? { ...i, qty: i.qty + delta } : i))
+        .filter((i) => i.qty > 0)
+    );
   };
 
   // --- LOGIC HOLD BILL ---
@@ -133,7 +166,19 @@ export default function POSPage() {
     if (cart.length === 0 || isSubmitting) return;
     if (override && !overrideReason.trim()) return alert("Alasan override wajib diisi!");
 
-    setIsSubmitting(true);
+    const unavailableCartItems = getUnavailableCartItems();
+
+    if (unavailableCartItems.length > 0) {
+      alert(
+        `Ada menu yang sudah tidak tersedia: ${unavailableCartItems
+          .map((item) => item.name)
+          .join(", ")}. Hapus menu tersebut dari keranjang sebelum melanjutkan pembayaran.`
+      );
+      return;
+    }
+
+  setIsSubmitting(true);
+
     try {
       let orderId: number;
       if (pendingOrderId !== null) { orderId = pendingOrderId; } 
@@ -163,8 +208,37 @@ export default function POSPage() {
       setCart([]); setCustomerName(""); setCashReceived(""); setOverrideReason(""); 
       setIsCashModalOpen(false); setIsQrisModalOpen(false); setIsShortageModalOpen(false);
       setPendingOrderId(null); setShowSuccessModal(true);
-    } catch (error: any) { alert(error.message); } finally { setIsSubmitting(false); }
-  };
+      } catch (error: any) {
+        const payload = error?.payload;
+        const code = error?.code || payload?.error;
+
+        if (code === "MENU_NOT_AVAILABLE") {
+          const menuNames = Array.isArray(payload?.menus)
+            ? payload.menus
+                .map((menu: { name?: string }) => menu.name)
+                .filter(Boolean)
+                .join(", ")
+            : "";
+
+          alert(
+            menuNames
+              ? `Menu sedang tidak tersedia: ${menuNames}. Hapus menu tersebut dari keranjang sebelum melanjutkan pembayaran.`
+              : "Ada menu yang sedang tidak tersedia. Hapus menu tersebut dari keranjang sebelum melanjutkan pembayaran."
+          );
+
+          setPendingOrderId(null);
+          setIsCashModalOpen(false);
+          setIsQrisModalOpen(false);
+          setIsShortageModalOpen(false);
+
+          return;
+        }
+
+        alert(error?.message || "Gagal memproses pembayaran.");
+      } finally {
+        setIsSubmitting(false);
+      }  
+};
 
   const totalTagihan = cart.reduce((sum, item) => sum + item.price * item.qty, 0);
   const filteredMenus = menus.filter((menu) => menu.name.toLowerCase().includes(searchQuery.toLowerCase()) && (selectedCategory === "ALL" || String(menu.category?.id ?? "") === selectedCategory));
@@ -221,9 +295,19 @@ export default function POSPage() {
         <main className="flex-1 overflow-y-auto p-3 md:p-4 lg:p-6">
           <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 2xl:grid-cols-8 gap-3 sm:gap-4">
             {filteredMenus.map((menu) => (
-              <button key={menu.id} onClick={() => addToCart(menu)} className="w-full max-w-32 aspect-square mx-auto bg-kanovi-dark text-white dark:bg-[#EADBC8] dark:text-kanovi-coffee rounded-xl p-3 flex flex-col justify-between items-start text-left shadow-sm active:scale-95 transition-all border border-black/5 dark:border-white/5">
+              <button key={menu.id} type="button" onClick={() => addToCart(menu)} disabled={!menu.isAvailable} title={menu.isAvailable? `Tambah ${menu.name}`: `${menu.name} sedang tidak tersedia`} className={`w-full max-w-32 aspect-square mx-auto rounded-xl p-3 flex flex-col justify-between items-start text-left shadow-sm transition-all border border-black/5 dark:border-white/5 ${ menu.isAvailable? "bg-kanovi-dark text-white dark:bg-[#EADBC8] dark:text-kanovi-coffee active:scale-95 hover:shadow-md" : "bg-kanovi-dark/50 text-white/70 dark:bg-[#EADBC8]/50 dark:text-kanovi-coffee/60 opacity-60 cursor-not-allowed grayscale"}`}>                
                 <span className="font-bold text-xs leading-tight line-clamp-3">{menu.name}</span>
-                <span className="font-medium text-[11px] opacity-90">Rp {menu.price.toLocaleString("id-ID")}</span>
+                    <div className="flex flex-col gap-1">
+                      <span className="font-medium text-[11px] opacity-90">
+                        Rp {menu.price.toLocaleString("id-ID")}
+                      </span>
+
+                      {!menu.isAvailable && (
+                        <span className="inline-flex w-fit rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-bold text-red-700 dark:bg-red-500/20 dark:text-red-300">
+                          Tidak Tersedia
+                      </span>
+                    )}
+                  </div>
               </button>
             ))}
           </div>
@@ -269,19 +353,50 @@ export default function POSPage() {
             <div className="flex-1 flex flex-col items-center justify-center opacity-30 text-kanovi-coffee dark:text-white gap-4"><ShoppingCart className="w-16 h-16" /><p className="text-sm font-medium">Belum ada pesanan</p></div>
           ) : (
             <div className="flex flex-col gap-1 w-full mt-2">
-              {cart.map((item) => (
-                <div key={item.id} className="flex flex-col py-3 border-b border-kanovi-cream/30 dark:border-white/5 last:border-0">
-                  <h4 className="font-semibold text-kanovi-coffee dark:text-white text-xs md:text-sm leading-tight mb-1.5">{item.name}</h4>
-                  <div className="flex justify-between items-center">
-                    <div className="text-kanovi-wood dark:text-kanovi-cream/70 text-xs md:text-sm font-medium">Rp {(item.price * item.qty).toLocaleString("id-ID")}</div>
-                    <div className="flex items-center gap-1 md:gap-2 bg-kanovi-bone dark:bg-kanovi-dark rounded-full p-1 border border-kanovi-cream/50 dark:border-white/5">
-                      <button onClick={() => updateQty(item.id, -1)} className="w-6 h-6 md:w-7 md:h-7 rounded-full bg-kanovi-paper dark:bg-kanovi-darker flex items-center justify-center text-kanovi-coffee dark:text-kanovi-cream hover:bg-kanovi-wood transition-colors shadow-sm"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3 h-3 md:w-3.5 md:h-3.5"><line x1="5" y1="12" x2="19" y2="12"></line></svg></button>
-                      <span className="font-bold text-xs md:text-sm w-4 md:w-5 text-center text-kanovi-coffee dark:text-white">{item.qty}</span>
-                      <button onClick={() => updateQty(item.id, 1)} className="w-6 h-6 md:w-7 md:h-7 rounded-full bg-kanovi-paper dark:bg-kanovi-darker flex items-center justify-center text-kanovi-coffee dark:text-kanovi-cream hover:bg-kanovi-wood transition-colors shadow-sm"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3 h-3 md:w-3.5 md:h-3.5"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg></button>
+              {cart.map((item) => {
+                const latestMenu = menus.find((menu) => menu.id === item.id);
+                const isUnavailable = latestMenu?.isAvailable === false;
+
+                return (
+                  <div key={item.id} className="flex flex-col py-3 border-b border-kanovi-cream/30 dark:border-white/5 last:border-0">
+                    <div className="flex items-start justify-between gap-2 mb-1.5">
+                      <h4 className="font-semibold text-kanovi-coffee dark:text-white text-xs md:text-sm leading-tight">{item.name}
+                      </h4>
+
+                      {isUnavailable && (
+                        <span className="shrink-0 rounded-full bg-red-100 px-2 py-0.5 text-[9px] font-bold text-red-700 dark:bg-red-500/20 dark:text-red-300">
+                          Tidak Tersedia
+                        </span>
+                      )}
+                    </div>
+
+                    <div className="flex justify-between items-center">
+                      <div className="text-kanovi-wood dark:text-kanovi-cream/70 text-xs md:text-sm font-medium">
+                        Rp {(item.price * item.qty).toLocaleString("id-ID")}
+                      </div>
+
+                      <div className="flex items-center gap-1 md:gap-2 bg-kanovi-bone dark:bg-kanovi-dark rounded-full p-1 border border-kanovi-cream/50 dark:border-white/5">
+                        <button type="button" onClick={() => updateQty(item.id, -1)} className="w-6 h-6 md:w-7 md:h-7 rounded-full bg-kanovi-paper dark:bg-kanovi-darker flex items-center justify-center text-kanovi-coffee dark:text-kanovi-cream hover:bg-kanovi-wood transition-colors shadow-sm">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3 h-3 md:w-3.5 md:h-3.5">
+                            <line x1="5" y1="12" x2="19" y2="12" />
+                          </svg>
+                        </button>
+
+                        <span className="font-bold text-xs md:text-sm w-4 md:w-5 text-center text-kanovi-coffee dark:text-white">
+                          {item.qty}
+                        </span>
+
+                        <button type="button" onClick={() => updateQty(item.id, 1)} disabled={isUnavailable} className="w-6 h-6 md:w-7 md:h-7 rounded-full bg-kanovi-paper dark:bg-kanovi-darker flex items-center justify-center text-kanovi-coffee dark:text-kanovi-cream hover:bg-kanovi-wood transition-colors shadow-sm disabled:opacity-40 disabled:cursor-not-allowed">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-3 h-3 md:w-3.5 md:h-3.5">
+                            <line x1="12" y1="5" x2="12" y2="19" />
+                            <line x1="5" y1="12" x2="19" y2="12" />
+                          </svg>
+                        </button>
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -9,6 +9,21 @@ export const getToken = (): string | undefined => {
     ?.split("=")[1];
 };
 
+export class ApiError extends Error {
+  status: number;
+  code?: string;
+  payload: any;
+
+  constructor(status: number, payload: any, fallbackMessage = "Terjadi kesalahan pada server") {
+    super(payload?.message || payload?.error || fallbackMessage);
+
+    this.name = "ApiError";
+    this.status = status;
+    this.code = payload?.error;
+    this.payload = payload;
+  }
+}
+
 // Custom Fetcher yang otomatis memasukkan token
 export const fetchApi = async (endpoint: string, options: RequestInit = {}) => {
   const token = getToken();

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -19,9 +19,13 @@ export type Menu = {
   id: number;
   name: string;
   price: number;
+  isAvailable: boolean;
   categoryId?: number | null;
-  category?: Category | null;
-  prepStation: PrepStation;
+  category?: {
+    id: number;
+    name: string;
+    slug: string;
+  } | null;
 };
 
 export type CartItem = Menu & {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       react-hot-toast:
         specifier: ^2.6.0
         version: 2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.2.1
@@ -876,6 +879,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -1042,12 +1049,20 @@ packages:
   caniuse-lite@1.0.30001776:
     resolution: {integrity: sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1062,6 +1077,11 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -1411,6 +1431,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -2225,6 +2249,10 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -2428,9 +2456,17 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -2442,6 +2478,11 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
@@ -3123,6 +3164,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adler-32@1.3.1: {}
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -3313,12 +3356,19 @@ snapshots:
 
   caniuse-lite@1.0.30001776: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   client-only@0.0.1: {}
+
+  codepage@1.15.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3329,6 +3379,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   cookie@1.1.1: {}
+
+  crc-32@1.2.2: {}
 
   create-require@1.1.1: {}
 
@@ -3896,6 +3948,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  frac@1.1.2: {}
 
   fraction.js@5.3.4: {}
 
@@ -4730,6 +4784,10 @@ snapshots:
 
   split2@4.2.0: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stable-hash@0.0.5: {}
 
   stop-iteration-iterator@1.1.0:
@@ -5010,7 +5068,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -5025,6 +5087,16 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   yn@3.1.1: {}
 


### PR DESCRIPTION
## Summary
Menambahkan status ketersediaan menu agar menu yang tidak tersedia tidak bisa dipilih atau dipesan di POS.

## Changes
- Add `isAvailable` field to Menu model
- Add Prisma migration
- Update create/update menu API
- Add dashboard badge and availability toggle
- Add create/edit menu availability input
- Disable unavailable menu in POS
- Add cart validation for unavailable menu
- Add backend validation for unavailable menu order/payment
- Preserve backend error payload in API client

## Evidence
- Dashboard menu shows Tersedia / Tidak Tersedia badge
- POS shows unavailable menu as disabled
- Backend/POS validation blocks unavailable menu from order

## Testing
- [ ] Owner can toggle menu availability
- [ ] Unavailable menu stays visible in dashboard
- [ ] Unavailable menu appears disabled in POS
- [ ] Unavailable menu cannot be added to cart
- [ ] Cart with old unavailable menu cannot proceed to payment
- [ ] Backend returns 409 MENU_NOT_AVAILABLE