### PR TITLE
feat(queue): improve daily queue number format and order tracking

### DIFF
--- a/apps/api/prisma/migrations/20260608201246_queue_format/migration.sql
+++ b/apps/api/prisma/migrations/20260608201246_queue_format/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Order" ADD COLUMN     "queueNumber" TEXT;

--- a/apps/api/prisma/migrations/20260608203603_queue_format_number/migration.sql
+++ b/apps/api/prisma/migrations/20260608203603_queue_format_number/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[queueNumber]` on the table `Order` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Order_queueNumber_key" ON "Order"("queueNumber");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -154,6 +154,7 @@ model Recipe {
 
 model Order {
   id            Int            @id @default(autoincrement()) 
+  queueNumber String? @unique
   userId        Int            
   origin        Location       
   customerName  String?        

--- a/apps/api/src/controllers/orderController.ts
+++ b/apps/api/src/controllers/orderController.ts
@@ -112,6 +112,37 @@ async function getOrderStockSummary(orderId: number) {
   };
 }
 
+async function generateQueueNumber(tx: any) {
+  const now = new Date();
+
+  const startOfDay = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate()
+  );
+
+  const endOfDay = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + 1
+  );
+
+  const todayPaidOrders = await tx.order.count({
+    where: {
+      paymentStatus: "PAID",
+      paidAt: {
+        gte: startOfDay,
+        lt: endOfDay,
+      },
+    },
+  });
+
+  const day = String(now.getDate()).padStart(2, "0");
+  const sequence = String(todayPaidOrders + 1).padStart(3, "0");
+
+  return `#${day}-${sequence}`;
+}
+
 // ====== 3. FUNGSI CONTROLLER ======
 
 export const createOrder = async (req: FastifyRequest, reply: FastifyReply) => {
@@ -320,6 +351,8 @@ export const payOrder = async (req: FastifyRequest, reply: FastifyReply) => {
 
     const didOverride = shortages.length > 0 && overrideStock;
 
+    const queueNumber = await generateQueueNumber(tx);
+
     const paidOrder = await tx.order.update({
       where: { id: lockedOrder.id },
       data: {
@@ -328,6 +361,7 @@ export const payOrder = async (req: FastifyRequest, reply: FastifyReply) => {
         stockOverride: didOverride,
         overrideNote: didOverride ? overrideNote : null,
         paidAt: lockedOrder.paidAt ?? new Date(),
+        queueNumber,
       },
       include: { details: true },
     });

--- a/apps/api/src/controllers/queueController.ts
+++ b/apps/api/src/controllers/queueController.ts
@@ -45,7 +45,12 @@ export const getActiveQueue = async (request: FastifyRequest, reply: FastifyRepl
           },
         },
       },
-      include: {
+      select: {
+        id: true,
+        queueNumber: true,
+        status: true,
+        orderedAt: true,
+        customerName: true,
         user: true,
         details: {
           where: {
@@ -53,13 +58,23 @@ export const getActiveQueue = async (request: FastifyRequest, reply: FastifyRepl
             prepStatus: { not: "SERVED" },
           },
           include: {
-            menu: { include: { category: true } },
+            menu: {
+              include: {
+                category: true,
+              },
+            },
           },
-          orderBy: { id: "asc" },
+          orderBy: {
+            id: "asc",
+          },
         },
       },
-      orderBy: { orderedAt: "asc" },
+      orderBy: {
+        orderedAt: "asc",
+      },
     });
+    
+    console.log(orders[0]);
 
     return reply.send({ success: true, data: orders });
   } catch (error) {
@@ -153,18 +168,31 @@ export const updateOrderItemStatus = async (
 export const getOrderHistory = async (request: FastifyRequest, reply: FastifyReply) => {
   try {
     const orders = await prisma.order.findMany({
-      where: { paymentStatus: "PAID" },
-      include: {
+      where: {
+        paymentStatus: "PAID",
+      },
+      select: {
+        id: true,
+        queueNumber: true,
+        status: true,
+        paymentMethod: true,
+        totalPrice: true,
+        orderedAt: true,
+        customerName: true,
         user: true,
         details: {
           include: {
             menu: {
-              include: { category: true },
+              include: {
+                category: true,
+              },
             },
           },
         },
       },
-      orderBy: { orderedAt: "desc" },
+      orderBy: {
+        orderedAt: "desc",
+      },
     });
 
     return reply.send({ success: true, data: orders });

--- a/apps/web/app/components/PosModals.tsx
+++ b/apps/web/app/components/PosModals.tsx
@@ -153,7 +153,7 @@ export function ShortageModal({ isOpen, shortages, overrideReason, setOverrideRe
 }
 
 // --- MODAL SUCCESS ---
-export function SuccessModal({ isOpen, onClose, finalChange }: { isOpen: boolean, onClose: () => void, finalChange: number }) {
+export function SuccessModal({ isOpen, onClose, finalChange,   queueNumber }: { isOpen: boolean, onClose: () => void, finalChange: number; queueNumber: string }) {
   if (!isOpen) return null;
   return (
     <div className="fixed inset-0 z-200 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
@@ -162,6 +162,18 @@ export function SuccessModal({ isOpen, onClose, finalChange }: { isOpen: boolean
           <CheckCircle2 className="w-12 h-12 animate-bounce" />
         </div>
         <h2 className="text-2xl font-black mb-2 text-kanovi-coffee dark:text-kanovi-bone">Pembayaran Berhasil!</h2>
+
+        {queueNumber && (
+          <div className="mb-4">
+            <p className="text-xs font-bold uppercase opacity-70">
+              Nomor Antrian
+            </p>
+
+            <p className="text-3xl font-black">
+              {queueNumber}
+            </p>
+          </div>
+        )}
         
         <div className="bg-kanovi-bone dark:bg-black/20 rounded-2xl p-5 mb-8 mt-6 border border-kanovi-cream/50 dark:border-white/5">
           <p className="text-[10px] text-kanovi-coffee/70 dark:text-kanovi-cream/70 font-black tracking-widest uppercase mb-1">Kembalian Customer</p>

--- a/apps/web/app/features/queue/components/kitchen-order-card.tsx
+++ b/apps/web/app/features/queue/components/kitchen-order-card.tsx
@@ -17,9 +17,9 @@ export default function KitchenOrderCard({ order, now, onAdvanceStatus }: Props)
     <div className="rounded-2xl bg-kanovi-bone dark:bg-[#1a1a1a] border border-kanovi-cream/50 dark:border-white/5 shadow-sm p-4">
       <div className="flex items-start justify-between mb-4">
         <div>
-          <h2 className="text-lg font-bold text-kanovi-coffee dark:text-white">
-            Order #{order.id}
-          </h2>
+          <h3 className="text-lg font-bold text-kanovi-coffee dark:text-white">
+            {order.queueNumber || `#${order.id}`}
+          </h3>
           <p className="text-sm text-kanovi-coffee/70 dark:text-gray-400">
             {order.customerName || "Walk-in"}
           </p>

--- a/apps/web/app/pos/page.tsx
+++ b/apps/web/app/pos/page.tsx
@@ -37,6 +37,7 @@ export default function POSPage() {
 
   const [finalChange, setFinalChange] = useState(0);
   const [receipt, setReceipt] = useState<ReceiptData | null>(null);
+  const [queueNumber, setQueueNumber] = useState("");
   const [pendingPaymentMethod, setPendingPaymentMethod] = useState<PaymentMethod | null>(null);
   const [pendingOrderId, setPendingOrderId] = useState<number | null>(null);
   const [shortages, setShortages] = useState<ShortageItem[]>([]);
@@ -199,7 +200,13 @@ export default function POSPage() {
         }
       }
 
-      await api.payOrder(orderId, { paymentMethod: method, overrideStock: override, overrideNote: override ? overrideReason : undefined });
+      const paymentResult = await api.payOrder(orderId, {
+        paymentMethod: method, 
+        overrideStock: override, 
+        overrideNote: override ? overrideReason : undefined 
+      });
+
+      setQueueNumber(paymentResult.order.queueNumber || "");
 
       const total = cart.reduce((sum, item) => sum + item.price * item.qty, 0);
       const cashNumInput = parseInt(cashReceived.replace(/[^0-9]/g, "")) || 0;
@@ -208,6 +215,7 @@ export default function POSPage() {
 
       const receiptData = buildReceiptData({
         orderId,
+        queueNumber: paymentResult.order.queueNumber,
         customerName,
         cart,
         paymentMethod: method,
@@ -217,11 +225,16 @@ export default function POSPage() {
         posName: "POS 1",
       });
 
+      localStorage.setItem(
+      "pending_receipt",
+      JSON.stringify(receiptData)
+    );
+
       setReceipt(receiptData);
       setFinalChange(changeAmount);
       setCart([]); setCustomerName(""); setCashReceived(""); setOverrideReason(""); 
       setIsCashModalOpen(false); setIsQrisModalOpen(false); setIsShortageModalOpen(false);
-      setPendingOrderId(null); setShowSuccessModal(false);
+      setPendingOrderId(null); setShowSuccessModal(true);
       } catch (error: any) {
         const payload = error?.payload;
         const code = error?.code || payload?.error;
@@ -455,8 +468,23 @@ export default function POSPage() {
       <CashModal isOpen={isCashModalOpen} onClose={() => setIsCashModalOpen(false)} totalTagihan={totalTagihan} cashReceived={cashReceived} setCashReceived={setCashReceived} uniqueSuggestedAmounts={uniqueSuggestedAmounts} isEnough={cashNum >= totalTagihan} kembalian={cashNum - totalTagihan} cashNum={cashNum} isSubmitting={isSubmitting} onProcess={handleProcessPayment} />
       <QrisModal isOpen={isQrisModalOpen} onClose={() => setIsQrisModalOpen(false)} totalTagihan={totalTagihan} isSubmitting={isSubmitting} onProcess={handleProcessPayment} />
       <ShortageModal isOpen={isShortageModalOpen} shortages={shortages} overrideReason={overrideReason} setOverrideReason={setOverrideReason} isSubmitting={isSubmitting} onCancel={() => setIsShortageModalOpen(false)} onProcess={handleProcessPayment} pendingMethod={pendingPaymentMethod} />
-      <SuccessModal isOpen={showSuccessModal} onClose={() => setShowSuccessModal(false)} finalChange={finalChange} />
+      <SuccessModal
+        isOpen={showSuccessModal}
+        finalChange={finalChange}
+        queueNumber={queueNumber}
+        onClose={() => {
+          setShowSuccessModal(false);
 
+          const pendingReceipt = localStorage.getItem(
+            "pending_receipt"
+          );
+
+          if (pendingReceipt) {
+            setReceipt(JSON.parse(pendingReceipt));
+            localStorage.removeItem("pending_receipt");
+          }
+        }}
+      />      
       <ExpenseModal isOpen={isExpenseOpen} onClose={() => setIsExpenseOpen(false)} sessionId={activeSession?.id} />
       <ClosingModal isOpen={isClosingOpen} onClose={() => setIsClosingOpen(false)} sessionId={activeSession?.id} onClosingSuccess={() => { setActiveSession(null); setIsClosingOpen(false); localStorage.removeItem("kanovi_branch"); document.cookie = "kanovi_token=; path=/; max-age=0;"; router.push("/login"); }} />
       
@@ -472,7 +500,7 @@ export default function POSPage() {
           receipt={receipt}
           onClose={() => {
             setReceipt(null);
-            setShowSuccessModal(false);
+            setQueueNumber("");
           }}
         />
       )}

--- a/apps/web/lib/receipt.ts
+++ b/apps/web/lib/receipt.ts
@@ -2,6 +2,7 @@ import type { CartItem, PaymentMethod, ReceiptData, ReceiptItem } from "../types
 
 type BuildReceiptParams = {
   orderId: number;
+  queueNumber?: string;
   customerName: string;
   cart: CartItem[];
   paymentMethod: PaymentMethod;
@@ -30,6 +31,7 @@ export const formatReceiptDate = (date: string) =>
 
 export const buildReceiptData = ({
   orderId,
+  queueNumber,
   customerName,
   cart,
   paymentMethod,
@@ -47,8 +49,6 @@ export const buildReceiptData = ({
   }));
 
   const total = items.reduce((sum, item) => sum + item.subtotal, 0);
-  const queueNumber = `#01-${String(orderId).padStart(3, "0")}`;
-
   return {
     orderId,
     orderNumber: `#${orderId}`,

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -34,6 +34,7 @@ export type CartItem = Menu & {
 
 export type OrderDetail = {
   id: number;
+  queueNumber?: string;
   orderId: number;
   menuId: number;
   qty: number;
@@ -50,6 +51,7 @@ export type OrderDetail = {
 
 export type Order = {
   id: number;
+  queueNumber?: string;
   customerName: string | null;
   status: "NEW" | "IN_PROGRESS" | "READY" | "DONE" | "CANCELED";
   paymentStatus: "UNPAID" | "PAID" | "VOID";
@@ -164,7 +166,7 @@ export type ReceiptItem = {
 export type ReceiptData = {
   orderId: number;
   orderNumber: string;
-  queueNumber: string;
+  queueNumber?: string;
   customerName?: string;
   employeeName: string;
   posName: string;


### PR DESCRIPTION
- implement automatic daily queue numbering (#DD-NNN)
- store queue numbers per paid order
- return queue number in payment and queue responses
- add queue number to POS success modal
- add queue number to receipt preview
- replace order id display with queue number in kitchen display
- update frontend receipt and order types
- refine payment success -> receipt workflow
- support operational queue monitoring for barista and kitchen staff
- fulfill queue numbering requirements from SRS FR-7, FR-8, FR-16 and FR-17