### PR TITLE
feat(auth): add role protection for finance and void routes

### DIFF
--- a/apps/api/prisma/migrations/20260427020242_init/migration.sql
+++ b/apps/api/prisma/migrations/20260427020242_init/migration.sql
@@ -1,0 +1,58 @@
+-- CreateEnum
+CREATE TYPE "Branch" AS ENUM ('PUSAT', 'RESTART');
+
+-- CreateEnum
+CREATE TYPE "SessionStatus" AS ENUM ('OPEN', 'CLOSED');
+
+-- AlterTable
+ALTER TABLE "Order" ADD COLUMN     "branch" "Branch" NOT NULL DEFAULT 'PUSAT',
+ADD COLUMN     "sessionId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "CashSession" (
+    "id" SERIAL NOT NULL,
+    "branch" "Branch" NOT NULL,
+    "openedBy" TEXT NOT NULL,
+    "openedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "initialCash" INTEGER NOT NULL,
+    "status" "SessionStatus" NOT NULL DEFAULT 'OPEN',
+    "closedBy" TEXT,
+    "closedAt" TIMESTAMP(3),
+    "expectedCash" INTEGER,
+    "actualCash" INTEGER,
+    "difference" INTEGER,
+    "note" TEXT,
+
+    CONSTRAINT "CashSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Expense" (
+    "id" SERIAL NOT NULL,
+    "sessionId" INTEGER NOT NULL,
+    "branch" "Branch" NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "description" TEXT NOT NULL,
+    "recordedBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Expense_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CashSession_status_idx" ON "CashSession"("status");
+
+-- CreateIndex
+CREATE INDEX "CashSession_branch_idx" ON "CashSession"("branch");
+
+-- CreateIndex
+CREATE INDEX "Expense_sessionId_idx" ON "Expense"("sessionId");
+
+-- CreateIndex
+CREATE INDEX "Order_sessionId_idx" ON "Order"("sessionId");
+
+-- AddForeignKey
+ALTER TABLE "Order" ADD CONSTRAINT "Order_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "CashSession"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "CashSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/src/controllers/authController.ts
+++ b/apps/api/src/controllers/authController.ts
@@ -6,7 +6,7 @@ import jwt from 'jsonwebtoken';
 const prisma = new PrismaClient();
 
 export const loginUser = async (req: FastifyRequest, reply: FastifyReply) => {
-  // Ambil data dari body (di-cast ke any sementara karena tipe body bawaan Fastify adalah unknown)
+
   const { username, password } = req.body as any;
 
   if (!username) {
@@ -28,10 +28,16 @@ export const loginUser = async (req: FastifyRequest, reply: FastifyReply) => {
       return reply.code(401).send({ message: "Username atau password salah" });
     }
 
+    if (!process.env.JWT_SECRET) {
+      return reply.code(500).send({
+        message: "JWT_SECRET belum diatur di server.",
+      });
+    }
+
     const token = jwt.sign(
-      { userId: user.id, role: user.role }, 
-      process.env.JWT_SECRET || 'rahasia_negara', 
-      { expiresIn: '1d' }
+      { userId: user.id, role: user.role },
+      process.env.JWT_SECRET,
+      { expiresIn: "1d" }
     );
 
     return reply.code(200).send({ 

--- a/apps/api/src/middleware/authMiddleware.ts
+++ b/apps/api/src/middleware/authMiddleware.ts
@@ -1,7 +1,6 @@
-import { FastifyRequest, FastifyReply } from 'fastify';
-import jwt from 'jsonwebtoken';
+import { FastifyReply, FastifyRequest } from "fastify";
+import jwt from "jsonwebtoken";
 
-// 1. Sesuaikan Payload dengan tipe data di fastify.d.ts (id menggunakan number)
 interface JwtPayload {
   id?: number;
   userId?: number;
@@ -9,34 +8,51 @@ interface JwtPayload {
   username?: string;
 }
 
-export const verifyToken = async (request: FastifyRequest, reply: FastifyReply) => {
-  const authHeader = request.headers['authorization'];
-  
-  // 2. Validasi ganda: Pastikan header ada DAN formatnya benar berawalan "Bearer "
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return reply.code(401).send({ 
-      success: false, 
-      message: "Akses ditolak. Token tidak ditemukan atau format salah." 
+const getJwtSecret = () => {
+  const secret = process.env.JWT_SECRET;
+
+  if (!secret) {
+    throw new Error("JWT_SECRET belum diatur di environment variable.");
+  }
+
+  return secret;
+};
+
+export const verifyToken = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const authHeader = request.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return reply.code(401).send({
+      success: false,
+      message: "Akses ditolak. Token tidak ditemukan atau format salah.",
     });
   }
 
-  // 3. Ambil token aslinya
-  const token = authHeader.split(' ')[1];
-  
+  const token = authHeader.split(" ")[1];
+
   try {
-    // 4. Verifikasi dan paksa tipe datanya menjadi JwtPayload yang baru
-    const decoded = jwt.verify(
-      token, 
-      process.env.JWT_SECRET || 'rahasia_negara'
-    ) as JwtPayload;
-    
-    // 5. Simpan data hasil decode ke object request. 
-    request.user = decoded; 
-    
-  } catch (error) {
-    return reply.code(401).send({ 
-      success: false, 
-      message: "Akses ditolak. Token tidak valid atau sudah kadaluarsa." 
+    const decoded = jwt.verify(token, getJwtSecret()) as JwtPayload;
+    request.user = decoded;
+  } catch {
+    return reply.code(401).send({
+      success: false,
+      message: "Akses ditolak. Token tidak valid atau sudah kedaluwarsa.",
     });
   }
+};
+
+export const allowRoles = (roles: string[]) => {
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    const userRole = request.user?.role;
+
+    if (!userRole || !roles.includes(userRole)) {
+      return reply.code(403).send({
+        success: false,
+        message: "Akses ditolak. Anda tidak memiliki izin untuk fitur ini.",
+      });
+    }
+  };
 };

--- a/apps/api/src/routes/financeRoutes.ts
+++ b/apps/api/src/routes/financeRoutes.ts
@@ -1,11 +1,44 @@
 import { FastifyInstance } from "fastify";
 import { financeController } from "../controllers/financeController";
+import { verifyToken, allowRoles } from "../middleware/authMiddleware";
+
+const ownerOnly = [verifyToken, allowRoles(["OWNER"])];
+const cashierOrOwner = [verifyToken, allowRoles(["OWNER", "MANAGER", "PEGAWAI"])];
 
 export default async function financeRoutes(fastify: FastifyInstance) {
-  fastify.get("/sessions/active", financeController.getActiveSession);
-  fastify.post("/sessions/open", financeController.openSession);
-  fastify.post("/sessions/close", financeController.closeSession);
-  fastify.patch("/sessions/:id", financeController.updateSession);
-  fastify.post("/expenses", financeController.createExpense); 
-  fastify.get("/report", financeController.getFinanceReport);
+  fastify.get(
+    "/sessions/active",
+    { preHandler: cashierOrOwner },
+    financeController.getActiveSession
+  );
+
+  fastify.post(
+    "/sessions/open",
+    { preHandler: cashierOrOwner },
+    financeController.openSession
+  );
+
+  fastify.post(
+    "/sessions/close",
+    { preHandler: ownerOnly },
+    financeController.closeSession
+  );
+
+  fastify.patch(
+    "/sessions/:id",
+    { preHandler: ownerOnly },
+    financeController.updateSession
+  );
+
+  fastify.post(
+    "/expenses",
+    { preHandler: ownerOnly },
+    financeController.createExpense
+  );
+
+  fastify.get(
+    "/report",
+    { preHandler: ownerOnly },
+    financeController.getFinanceReport
+  );
 }

--- a/apps/api/src/routes/orderRoutes.ts
+++ b/apps/api/src/routes/orderRoutes.ts
@@ -1,10 +1,20 @@
 import { FastifyInstance } from "fastify";
-import { verifyToken } from "../middleware/authMiddleware";
-import { createOrder, checkOrderStock, payOrder, voidOrder } from "../controllers/orderController";
+import { verifyToken, allowRoles } from "../middleware/authMiddleware";
+import {
+  createOrder,
+  checkOrderStock,
+  payOrder,
+  voidOrder,
+} from "../controllers/orderController";
 
 export default async function orderRoutes(app: FastifyInstance) {
   app.post("/", { preHandler: [verifyToken] }, createOrder);
   app.get("/:id/stock-check", { preHandler: [verifyToken] }, checkOrderStock);
   app.post("/:id/pay", { preHandler: [verifyToken] }, payOrder);
-  app.post("/:id/void", voidOrder);
+
+  app.post(
+    "/:id/void",
+    { preHandler: [verifyToken, allowRoles(["OWNER", "MANAGER"])] },
+    voidOrder
+  );
 }


### PR DESCRIPTION
## Apa yang berubah?
- Menambahkan proteksi autentikasi JWT pada route finance.
- Menambahkan proteksi autentikasi JWT pada route void order.
- Menambahkan role-based authorization agar fitur sensitif hanya bisa diakses oleh role yang sesuai.
- Menghapus fallback JWT secret default agar token hanya dibuat jika `JWT_SECRET` tersedia di environment.

## Kenapa?
Route finance dan void order termasuk fitur sensitif karena berhubungan dengan laporan keuangan dan pembatalan transaksi. Proteksi ini diperlukan agar user tanpa token tidak bisa mengakses route tersebut, dan user dengan role yang tidak sesuai tetap ditolak.

## Cara test
- [x] `pnpm --filter api lint`
- [x] `pnpm --filter api build`
- [x] Login sebagai pegawai/kasir lalu akses `/dashboard/finance`, sistem diarahkan kembali ke halaman POS.
- [x] API finance/void sudah menggunakan JWT authentication dan role authorization.

## Catatan
Perubahan ini menyelesaikan issue #50.